### PR TITLE
Fixes "Url not valid for author" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A responsive, clean card theme for the Ghost blogging platform.",
   "author": {
     "name": "Daan Beverdam",
-    "url": "www.daanbeverdam.com"
+    "url": "https://www.daanbeverdam.com"
   },
   "config": {
     "posts_per_page": 11


### PR DESCRIPTION
This warning occurs when you upload the theme to Ghost. It appears that you need the URL protocol.